### PR TITLE
Fix: Prevent game start without player name

### DIFF
--- a/script.js
+++ b/script.js
@@ -33,6 +33,11 @@ function toggleTheme() {
         themeIcon.textContent = '🌙';
     }
 }
+if (!playerName || playerName.trim() === "") {
+    alert("Player name is required");
+    return;
+}
+
 
 function switchTab(tabName) {
     const tabs = document.querySelectorAll('.tab-content');


### PR DESCRIPTION
Fixes #1

Added validation to prevent starting the game without entering a player name.
Displays validation message if input is empty.
